### PR TITLE
Feature/some fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from './test-plugin';
 export * from './test-plugin-configuration';
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './test-plugin';
 export * from './test-plugin-configuration';
+export * from './example/index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './test-plugin';
 export * from './test-plugin-configuration';
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from './test-plugin';
 export * from './test-plugin-configuration';
-export * from './example';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,8 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "noEmitHelpers": false
+    "noEmitHelpers": false,
+    "emitDecoratorMetadata": true
   },
   "exclude": [
     ".vscode",


### PR DESCRIPTION
Dieser Branch behebt zwei Probleme:

1. Die view-models werden nicht mehr exportiert, da das importieren des transpilierten Quellcodes für Probleme gesorgt hat (Ordner werden als Datei importiert)
2. Der `autoinject` (und vermutlich auch andere) Decorator funktionierte nicht, da `emitDecoratorMetadata` in der tsconfig fehlte.